### PR TITLE
Abstract join game endpoint with `create_or_join`

### DIFF
--- a/src/handlers/game/join_game.rs
+++ b/src/handlers/game/join_game.rs
@@ -1,15 +1,13 @@
-use std::env;
 use parking_lot::Mutex;
 use actix_session::Session;
 use actix_web::web::Data;
 use actix_web::{HttpRequest, HttpResponse, post};
 
 use crate::common::WebErr;
-use crate::helpers::general::{get_user_with_relations, get_username, send_lobby_event, set_user_playing};
-use crate::models::events::{UserEvent, GameStartEvent, UserEventType};
-use crate::models::general::{GameStatus, GameKey};
+use crate::helpers::general::{get_user_with_relations, get_username};
+use crate::helpers::create_game::{join_game as join_game_util};
 use crate::models::res::OK_RES;
-use crate::prisma::{PrismaClient, game, user};
+use crate::prisma::{PrismaClient, game};
 use crate::sse::Broadcaster;
 
 
@@ -34,46 +32,9 @@ pub async fn join_game(
         .ok_or(WebErr::NotFound(format!("could not find game with id {}", game_id)))?;
 
     let user = get_user_with_relations(&client, &username.clone()).await?;
-    let perf = user.perfs.as_ref().unwrap().iter().find(|p| p.game_key == game.game_key).unwrap();
+    let perf = user.perfs().unwrap().iter().find(|p| p.game_key == game.game_key).unwrap();
 
-    let updated_game = client
-        .game()
-        .update(
-            game::id::equals(game_id.clone()),
-            if game.first_username.is_none() {
-                vec![
-                    game::status::set(GameStatus::Started.to_string()), // TODO: dedupe?
-                    game::first_user::connect(user::username::equals(username)),
-                    game::first_rating::set(Some(perf.rating as i32)),
-                    game::first_prov::set(Some(perf.prov)),
-                ]
-            } else {
-                vec![
-                    game::status::set(GameStatus::Started.to_string()), // TODO: dedupe?
-                    game::second_user::connect(user::username::equals(username)),
-                    game::second_rating::set(Some(perf.rating as i32)),
-                    game::second_prov::set(Some(perf.prov)),
-                ]
-            },
-        )
-        .exec()
-        .await
-        .or(Err(WebErr::Internal(format!("error updating game with id {}", game_id))))?;
-
-    broadcaster.lock().user_send(&updated_game.first_username.clone().unwrap(), UserEvent::GameStartEvent(GameStartEvent {
-        r#type: UserEventType::GameStart,
-        game: GameKey::from_str(&updated_game.game_key)?,
-        id: game.id.clone(),
-    }));
-    broadcaster.lock().user_send(&updated_game.second_username.clone().unwrap(), UserEvent::GameStartEvent(GameStartEvent {
-        r#type: UserEventType::GameStart,
-        game: GameKey::from_str(&updated_game.game_key)?,
-        id: game.id.clone(),
-    }));
-
-    set_user_playing(&client, &updated_game.first_username.clone().unwrap(), Some([env::var("DOMAIN").unwrap(), "/game/".to_string(), game.id.clone()].concat())).await?;
-    set_user_playing(&client, &updated_game.second_username.clone().unwrap(), Some([env::var("DOMAIN").unwrap(), "/game/".to_string(), game.id.clone()].concat())).await?;
-    send_lobby_event(&client, &broadcaster).await?;
+    join_game_util(&client, &game, game.first_user.is_none(), username, perf.rating as i32, perf.prov, &broadcaster).await?;
 
     Ok(HttpResponse::Ok().json(OK_RES))
 }

--- a/src/helpers/user.rs
+++ b/src/helpers/user.rs
@@ -80,7 +80,7 @@ impl user::Data {
 
     // method to get rating progression for game
     pub fn get_prog(&self, game_key: &str) -> Result<String, WebErr> {
-        let perfs: &Vec<crate::prisma::perf::Data> = self.perfs().or(Err(WebErr::Internal(format!("perfs not fetched"))))?;
+        let perfs = self.perfs().or(Err(WebErr::Internal(format!("perfs not fetched"))))?;
 
         Ok(perfs.iter().find(|p| p.game_key == game_key)
             .ok_or(WebErr::Internal(format!("could not find perf for {}", game_key)))?
@@ -117,7 +117,6 @@ impl user::Data {
     }
 
     pub fn to_match_player(&self, game_key: &str, req: &CreateGameReq) -> MatchPlayer {
-
         let mut rng = rand::thread_rng();
 
         MatchPlayer {


### PR DESCRIPTION
The current method signature for `join_game` is a bit nasty because it needs to support both `CreateGameReq`'s `MatchPlayer` and regular endpoint `Player`s. It may be possible to get rid of `MatchPlayer` entirely, as most of the same data is represented already by `Player` and `Player.perfs()`?